### PR TITLE
Add web search grounding with engine selection and phase policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ consilium "Is consciousness computable?" --socratic
 --followup                  Interactive drill-down after synthesis (council mode)
 --rounds N                  Rounds for discuss/socratic (0 = unlimited)
 --effort low|medium|high    Per-phase reasoning effort for thinking models
+--web-search [N]            Web search grounding [default: 5 results, engine: exa]
+--web-engine ENGINE         Search engine: exa (default, ~$0.02/req), native (provider pricing), firecrawl, parallel
 --thorough                  Disable early consensus exit
 --output file.md            Save transcript to file
 --format json|yaml|prose    Output format

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,8 +2,8 @@
 
 use crate::config::{
     fallback_also_failed_message, is_error_response, is_thinking_model, model_max_output_tokens,
-    CostTracker, Message, ModelEntry, ReasoningEffort, ANTHROPIC_URL, ANTHROPIC_VERSION,
-    BIGMODEL_URL, GOOGLE_AI_STUDIO_URL, OPENROUTER_URL, XAI_URL,
+    CostTracker, Message, ModelEntry, QueryOptions, ReasoningEffort, WebSearchConfig,
+    ANTHROPIC_URL, ANTHROPIC_VERSION, BIGMODEL_URL, GOOGLE_AI_STUDIO_URL, OPENROUTER_URL, XAI_URL,
 };
 use crate::session::Output;
 use futures_util::StreamExt;
@@ -15,8 +15,18 @@ use std::time::Duration;
 use tokio::process::Command;
 use tokio::time::{sleep, timeout};
 
+/// Build the OpenRouter plugins JSON for web search.
+fn web_search_plugin_json(config: &WebSearchConfig) -> serde_json::Value {
+    serde_json::json!([{
+        "id": "web",
+        "max_results": config.max_results,
+        "engine": config.engine.as_str()
+    }])
+}
+
 /// Query the judge: try native direct API first (based on model), fall back to OpenRouter.
 /// Reads API keys from env directly to avoid threading through all mode signatures.
+/// Judge never uses web search — always uses high effort.
 pub async fn query_judge(
     client: &Client,
     openrouter_api_key: &str,
@@ -28,6 +38,7 @@ pub async fn query_judge(
     cost_tracker: Option<&CostTracker>,
 ) -> String {
     let effort = Some(ReasoningEffort::High);
+    let judge_opts = QueryOptions::new(effort, None);
     if model.contains("google/") || model.contains("gemini") {
         if let Ok(g_key) = std::env::var("GOOGLE_API_KEY") {
             if !g_key.trim().is_empty() {
@@ -83,7 +94,7 @@ pub async fn query_judge(
         timeout_secs,
         retries,
         cost_tracker,
-        effort,
+        &judge_opts,
     )
     .await
 }
@@ -98,7 +109,7 @@ pub async fn query_model(
     timeout_secs: f64,
     retries: u32,
     cost_tracker: Option<&CostTracker>,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> String {
     let mut max_tokens = max_tokens;
     let mut timeout_secs = timeout_secs;
@@ -111,7 +122,8 @@ pub async fn query_model(
         timeout_secs = timeout_secs.max(300.0);
     }
 
-    if model.contains("anthropic/") || model.contains("claude") {
+    // Skip native API fallbacks when web search is enabled — native APIs don't support plugins
+    if opts.web_search.is_none() && (model.contains("anthropic/") || model.contains("claude")) {
         let response = query_claude_print(model, messages, timeout_secs).await;
         if !is_error_response(&response) {
             return response;
@@ -129,8 +141,11 @@ pub async fn query_model(
             "messages": messages,
             "max_tokens": max_tokens,
         });
-        if let Some(effort) = effort {
+        if let Some(effort) = opts.effort {
             body["reasoning"] = serde_json::json!({ "effort": effort.as_str() });
+        }
+        if let Some(ref config) = opts.web_search {
+            body["plugins"] = web_search_plugin_json(config);
         }
 
         let result = client
@@ -766,7 +781,7 @@ pub async fn query_model_streaming(
     max_tokens: u32,
     timeout_secs: f64,
     cost_tracker: Option<&CostTracker>,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
     output: &mut dyn Output,
 ) -> String {
     let mut full_content = Vec::new();
@@ -778,10 +793,13 @@ pub async fn query_model_streaming(
         "max_tokens": max_tokens,
         "stream": true,
     });
-    if let Some(effort) = effort {
+    if let Some(effort) = opts.effort {
         body["reasoning"] = serde_json::json!({
             "effort": effort.as_str(),
         });
+    }
+    if let Some(ref config) = opts.web_search {
+        body["plugins"] = web_search_plugin_json(config);
     }
 
     let result = client
@@ -932,7 +950,7 @@ pub async fn query_model_with_fallback(
     timeout_secs: f64,
     retries: u32,
     cost_tracker: Option<&CostTracker>,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> (String, String, String) {
     let model_name = model.split('/').next_back().unwrap_or(model).to_string();
     let mut primary_response: Option<String> = None;
@@ -945,92 +963,95 @@ pub async fn query_model_with_fallback(
         60.0
     });
 
-    // For Claude: try Anthropic directly first
-    if let Some(("anthropic", anthropic_model)) = fallback {
-        if let Some(ant_key) = anthropic_api_key {
-            let response = query_anthropic(
-                client,
-                ant_key,
-                anthropic_model,
-                messages,
-                max_tokens,
-                timeout_secs,
-                retries,
-                effort,
-            )
-            .await;
-            if !is_error_response(&response) {
-                return (name.to_string(), anthropic_model.to_string(), response);
+    // Skip native API fallbacks when web search is enabled — native APIs don't support plugins
+    if opts.web_search.is_none() {
+        // For Claude: try Anthropic directly first
+        if let Some(("anthropic", anthropic_model)) = fallback {
+            if let Some(ant_key) = anthropic_api_key {
+                let response = query_anthropic(
+                    client,
+                    ant_key,
+                    anthropic_model,
+                    messages,
+                    max_tokens,
+                    timeout_secs,
+                    retries,
+                    opts.effort,
+                )
+                .await;
+                if !is_error_response(&response) {
+                    return (name.to_string(), anthropic_model.to_string(), response);
+                }
+                primary_response = Some(response);
+                // Anthropic failed — fall through to OpenRouter
             }
-            primary_response = Some(response);
-            // Anthropic failed — fall through to OpenRouter
         }
-    }
 
-    // For GLM: try bigmodel.cn directly first (more reliable than OpenRouter z-ai)
-    if let Some(("zhipu", zhipu_model)) = fallback {
-        if let Some(zapi_key) = zhipu_api_key {
-            let response = query_bigmodel(
-                client,
-                zapi_key,
-                zhipu_model,
-                messages,
-                max_tokens,
-                timeout_secs,
-                retries,
-            )
-            .await;
-            if !is_error_response(&response) {
-                return (name.to_string(), zhipu_model.to_string(), response);
+        // For GLM: try bigmodel.cn directly first (more reliable than OpenRouter z-ai)
+        if let Some(("zhipu", zhipu_model)) = fallback {
+            if let Some(zapi_key) = zhipu_api_key {
+                let response = query_bigmodel(
+                    client,
+                    zapi_key,
+                    zhipu_model,
+                    messages,
+                    max_tokens,
+                    timeout_secs,
+                    retries,
+                )
+                .await;
+                if !is_error_response(&response) {
+                    return (name.to_string(), zhipu_model.to_string(), response);
+                }
+                primary_response = Some(response);
+                // bigmodel.cn failed — fall through to OpenRouter
             }
-            primary_response = Some(response);
-            // bigmodel.cn failed — fall through to OpenRouter
         }
-    }
 
-    // For Grok: try xAI directly first
-    if let Some(("xai", xai_model)) = fallback {
-        if let Some(xapi_key) = xai_api_key {
-            let response = query_xai(
-                client,
-                xapi_key,
-                xai_model,
-                messages,
-                max_tokens,
-                timeout_secs,
-                retries,
-                effort,
-            )
-            .await;
-            if !is_error_response(&response) {
-                return (name.to_string(), xai_model.to_string(), response);
+        // For Grok: try xAI directly first
+        if let Some(("xai", xai_model)) = fallback {
+            if let Some(xapi_key) = xai_api_key {
+                let response = query_xai(
+                    client,
+                    xapi_key,
+                    xai_model,
+                    messages,
+                    max_tokens,
+                    timeout_secs,
+                    retries,
+                    opts.effort,
+                )
+                .await;
+                if !is_error_response(&response) {
+                    return (name.to_string(), xai_model.to_string(), response);
+                }
+                primary_response = Some(response);
+                // xAI failed — fall through to OpenRouter
             }
-            primary_response = Some(response);
-            // xAI failed — fall through to OpenRouter
         }
-    }
 
-    // For Gemini: try Google AI Studio directly first
-    if let Some(("google", google_model)) = fallback {
-        if let Some(gapi_key) = google_api_key {
-            let response = query_google_ai_studio(
-                client,
-                gapi_key,
-                google_model,
-                messages,
-                max_tokens,
-                timeout_secs,
-                retries,
-                effort,
-            )
-            .await;
-            if !is_error_response(&response) {
-                return (name.to_string(), google_model.to_string(), response);
+        // For Gemini: try Google AI Studio directly first
+        if let Some(("google", google_model)) = fallback {
+            if let Some(gapi_key) = google_api_key {
+                let response = query_google_ai_studio(
+                    client,
+                    gapi_key,
+                    google_model,
+                    messages,
+                    max_tokens,
+                    timeout_secs,
+                    retries,
+                    opts.effort,
+                )
+                .await;
+                if !is_error_response(&response) {
+                    return (name.to_string(), google_model.to_string(), response);
+                }
+                primary_response = Some(response);
+                // Google AI Studio failed — fall through to OpenRouter
             }
-            primary_response = Some(response);
-            // Google AI Studio failed — fall through to OpenRouter
         }
-    }
+    } // end native API skip block
 
     let response = query_model(
         client,
@@ -1041,7 +1062,7 @@ pub async fn query_model_with_fallback(
         timeout_secs,
         retries,
         cost_tracker,
-        effort,
+        opts,
     )
     .await;
 
@@ -1079,7 +1100,7 @@ pub async fn query_model_async(
     timeout_secs: f64,
     retries: u32,
     cost_tracker: Option<&CostTracker>,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> (String, String, String) {
     query_model_with_fallback(
         client,
@@ -1098,7 +1119,7 @@ pub async fn query_model_async(
         timeout_secs,
         retries,
         cost_tracker,
-        effort,
+        opts,
     )
     .await
 }
@@ -1117,7 +1138,7 @@ pub async fn run_parallel(
     max_tokens: u32,
     timeout_secs: f64,
     cost_tracker: Option<&CostTracker>,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
     output: Option<&mut dyn Output>,
 ) -> Vec<(String, String, String)> {
     let client = Client::new();
@@ -1152,6 +1173,7 @@ pub async fn run_parallel(
             let fallback_owned: Option<(String, String)> =
                 fallback.map(|(p, m)| (p.to_string(), m.to_string()));
             let cost_tracker = cost_tracker.cloned();
+            let opts = opts.clone();
 
             tokio::spawn(async move {
                 let fallback_ref: Option<(&str, &str)> = fallback_owned
@@ -1182,7 +1204,7 @@ pub async fn run_parallel(
                         timeout_secs,
                         2,
                         cost_tracker.as_ref(),
-                        effort,
+                        &opts,
                     ),
                 )
                 .await
@@ -1242,7 +1264,7 @@ pub async fn run_parallel_with_different_messages(
     max_tokens: u32,
     timeout_secs: f64,
     cost_tracker: Option<&CostTracker>,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
     output: Option<&mut dyn Output>,
 ) -> Vec<(String, String, String)> {
     assert_eq!(
@@ -1271,6 +1293,7 @@ pub async fn run_parallel_with_different_messages(
             let fallback_owned: Option<(String, String)> =
                 fallback.map(|(p, m)| (p.to_string(), m.to_string()));
             let cost_tracker = cost_tracker.cloned();
+            let opts = opts.clone();
 
             tokio::spawn(async move {
                 let fallback_ref: Option<(&str, &str)> = fallback_owned
@@ -1301,7 +1324,7 @@ pub async fn run_parallel_with_different_messages(
                         timeout_secs,
                         2,
                         cost_tracker.as_ref(),
-                        effort,
+                        &opts,
                     ),
                 )
                 .await
@@ -1384,7 +1407,7 @@ pub async fn classify_mode(
         15.0,
         2,
         cost_tracker,
-        None,
+        &QueryOptions::internal(),
     )
     .await;
 
@@ -1502,5 +1525,46 @@ mod tests {
         assert_eq!(content, "visible");
         // reasoning_details is present but we don't use it
         assert!(data["choices"][0]["delta"]["reasoning_details"].is_string());
+    }
+
+    // --- Web search plugins ---
+
+    #[test]
+    fn test_web_search_plugins_json() {
+        use crate::config::WebSearchConfig;
+        let config = WebSearchConfig::default();
+        let opts = QueryOptions::new(None, Some(config));
+        let mut body = serde_json::json!({"model": "test", "messages": []});
+        if let Some(ref config) = opts.web_search {
+            body["plugins"] = web_search_plugin_json(config);
+        }
+        let plugins = body["plugins"].as_array().unwrap();
+        assert_eq!(plugins.len(), 1);
+        assert_eq!(plugins[0]["id"], "web");
+        assert_eq!(plugins[0]["max_results"], 5);
+        assert_eq!(plugins[0]["engine"], "exa");
+    }
+
+    #[test]
+    fn test_no_plugins_without_web_search() {
+        let opts = QueryOptions::default();
+        let mut body = serde_json::json!({"model": "test", "messages": []});
+        if let Some(ref config) = opts.web_search {
+            body["plugins"] = web_search_plugin_json(config);
+        }
+        assert!(body.get("plugins").is_none());
+    }
+
+    #[test]
+    fn test_web_search_custom_max_results() {
+        use crate::config::{WebSearchConfig, SearchEngine};
+        let config = WebSearchConfig { max_results: 3, engine: SearchEngine::Native };
+        let opts = QueryOptions::new(None, Some(config));
+        let mut body = serde_json::json!({"model": "test", "messages": []});
+        if let Some(ref config) = opts.web_search {
+            body["plugins"] = web_search_plugin_json(config);
+        }
+        assert_eq!(body["plugins"][0]["max_results"], 3);
+        assert_eq!(body["plugins"][0]["engine"], "native");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 //! Command-line argument parsing via clap derive.
 
+use crate::config::SearchEngine;
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -89,6 +90,14 @@ pub struct Cli {
     /// Reasoning effort for thinking models: low, medium, high
     #[arg(long, help_heading = "Deliberation")]
     pub effort: Option<String>,
+
+    /// Enable web search grounding via OpenRouter [default: 5 results, engine: exa]
+    #[arg(long, help_heading = "Context", value_name = "N", default_missing_value = "5", num_args = 0..=1, value_parser = clap::value_parser!(u8).range(1..=255))]
+    pub web_search: Option<u8>,
+
+    /// Search engine for --web-search: exa (~$0.02/req), native (provider pricing, may cost significantly more), firecrawl, parallel
+    #[arg(long, help_heading = "Context", value_name = "ENGINE", requires = "web_search")]
+    pub web_engine: Option<SearchEngine>,
 
     /// Skip early consensus exit and context compression (full deliberation)
     #[arg(long, help_heading = "Deliberation")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -558,6 +558,68 @@ impl Default for CostTracker {
     }
 }
 
+/// Web search plugin configuration for OpenRouter.
+/// User-visible answer phases inherit session config; internal phases use none.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WebSearchConfig {
+    pub max_results: u8,
+    pub engine: SearchEngine,
+}
+
+impl Default for WebSearchConfig {
+    fn default() -> Self {
+        Self {
+            max_results: 5,
+            engine: SearchEngine::Exa,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum SearchEngine {
+    #[default]
+    Exa,
+    Native,
+    Firecrawl,
+    Parallel,
+}
+
+impl SearchEngine {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exa => "exa",
+            Self::Native => "native",
+            Self::Firecrawl => "firecrawl",
+            Self::Parallel => "parallel",
+        }
+    }
+}
+
+/// Per-request options threaded through all API calls.
+/// Web search is per-model, per-phase by design. User-visible answer phases inherit
+/// session opts; internal helper phases use `internal()`. Council judge is special-cased
+/// in `query_judge()`. Oxford prior/verdict remain search-on (user-visible, not `query_judge`).
+/// Clone-only (not Copy) to allow future Vec fields (e.g. tool definitions).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct QueryOptions {
+    pub effort: Option<ReasoningEffort>,
+    pub web_search: Option<WebSearchConfig>, // None = disabled
+}
+
+impl QueryOptions {
+    pub fn new(effort: Option<ReasoningEffort>, web_search: Option<WebSearchConfig>) -> Self {
+        Self { effort, web_search }
+    }
+
+    /// For internal helper phases — no web search, no session effort.
+    pub fn internal() -> Self {
+        Self {
+            effort: None,
+            web_search: None,
+        }
+    }
+}
+
 /// Chat message for API calls.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Message {
@@ -1085,6 +1147,59 @@ mod tests {
         tracker.add(0.05);
         clone.add(0.10);
         assert!((tracker.total() - 0.15).abs() < 0.001);
+    }
+
+    // --- QueryOptions ---
+
+    #[test]
+    fn test_query_options_default() {
+        let opts = QueryOptions::default();
+        assert_eq!(opts.effort, None);
+        assert_eq!(opts.web_search, None);
+    }
+
+    #[test]
+    fn test_query_options_with_web_search() {
+        let opts = QueryOptions::new(None, Some(WebSearchConfig::default()));
+        assert_eq!(opts.web_search, Some(WebSearchConfig::default()));
+        assert_eq!(opts.effort, None);
+    }
+
+    #[test]
+    fn test_query_options_with_effort_and_search() {
+        let config = WebSearchConfig { max_results: 3, engine: SearchEngine::Exa };
+        let opts = QueryOptions::new(Some(ReasoningEffort::High), Some(config.clone()));
+        assert_eq!(opts.effort, Some(ReasoningEffort::High));
+        assert_eq!(opts.web_search, Some(config));
+    }
+
+    #[test]
+    fn test_query_options_clone_is_independent() {
+        let opts = QueryOptions::new(Some(ReasoningEffort::Low), Some(WebSearchConfig::default()));
+        let clone = opts.clone();
+        assert_eq!(opts, clone);
+    }
+
+    #[test]
+    fn test_query_options_internal() {
+        let opts = QueryOptions::internal();
+        assert_eq!(opts.effort, None);
+        assert_eq!(opts.web_search, None);
+    }
+
+    #[test]
+    fn test_web_search_config_default_engine() {
+        let config = WebSearchConfig::default();
+        assert_eq!(config.max_results, 5);
+        assert_eq!(config.engine, SearchEngine::Exa);
+    }
+
+    #[test]
+    fn test_search_engine_as_str() {
+        assert_eq!(SearchEngine::Exa.as_str(), "exa");
+        assert_eq!(SearchEngine::Native.as_str(), "native");
+        assert_eq!(SearchEngine::Firecrawl.as_str(), "firecrawl");
+        assert_eq!(SearchEngine::Parallel.as_str(), "parallel");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use consilium::api::classify_mode;
 use consilium::cli::Cli;
 use consilium::config::{
     discuss_models, oxford_models, quick_models, redteam_models, resolved_council, CostTracker,
-    ReasoningEffort,
+    QueryOptions, ReasoningEffort, WebSearchConfig,
 };
 use consilium::modes::{council, discuss, forecast, oxford, premortem, quick, redteam};
 use consilium::session::{
@@ -149,6 +149,11 @@ async fn main() {
         auto_mode
     };
     let effort = args.effort.as_deref().and_then(ReasoningEffort::from_str);
+    let web_search = args.web_search.map(|max_results| WebSearchConfig {
+        max_results,
+        engine: args.web_engine.unwrap_or_default(),
+    });
+    let opts = QueryOptions::new(effort, web_search);
 
     let color = std::env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal();
     let piped = stdout_is_pipe();
@@ -183,7 +188,7 @@ async fn main() {
                 &mut *output,
                 &args.format,
                 args.timeout,
-                effort,
+                &opts,
             )
             .await
         }
@@ -202,7 +207,7 @@ async fn main() {
                 &args.format,
                 args.timeout,
                 &mut *output,
-                effort,
+                &opts,
             )
             .await
         }
@@ -221,7 +226,7 @@ async fn main() {
                 &args.format,
                 args.timeout,
                 &mut *output,
-                effort,
+                &opts,
             )
             .await
         }
@@ -240,6 +245,7 @@ async fn main() {
                 &args.format,
                 args.timeout,
                 &mut *output,
+                &opts,
             )
             .await
         }
@@ -258,6 +264,7 @@ async fn main() {
                 &args.format,
                 args.timeout,
                 &mut *output,
+                &opts,
             )
             .await
         }
@@ -279,7 +286,7 @@ async fn main() {
                 args.timeout,
                 &mut *output,
                 args.thorough,
-                effort,
+                &opts,
             )
             .await
         }
@@ -343,7 +350,7 @@ async fn main() {
                 args.xpol,
                 args.followup,
                 args.thorough,
-                effort,
+                &opts,
                 args.judge_model.as_deref(),
                 args.critic_model.as_deref(),
                 args.no_critic,

--- a/src/modes/council.rs
+++ b/src/modes/council.rs
@@ -4,7 +4,7 @@ use crate::api::{query_judge, query_model, query_model_async, run_parallel};
 use crate::config::{
     detect_consensus, detect_social_context, is_error_response, model_max_output_tokens,
     parse_confidence, resolved_critique_model_with_override, resolved_judge_model_with_override,
-    sanitize_speaker_content, CostTracker, Message, ModelEntry, ReasoningEffort, SessionResult,
+    sanitize_speaker_content, CostTracker, Message, ModelEntry, QueryOptions, SessionResult,
     EXTRACTION_MODEL,
 };
 use crate::prompts::{
@@ -224,7 +224,7 @@ pub async fn extract_structured_summary(
             30.0,
             2,
             cost_tracker,
-            None,
+            &QueryOptions::internal(),
         )
         .await
         .trim()
@@ -368,7 +368,7 @@ pub async fn decompose_question(
         120.0,
         2,
         Some(cost_tracker),
-        None,
+        &QueryOptions::internal(),
     )
     .await;
 
@@ -433,7 +433,7 @@ async fn compress_round_context(
         30.0,
         2,
         Some(cost_tracker),
-        None,
+        &QueryOptions::internal(),
     )
     .await;
 
@@ -465,7 +465,7 @@ async fn run_blind_phase_parallel(
     domain_hint: Option<&str>,
     sub_questions: Option<&[String]>,
     cost_tracker: &CostTracker,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> Vec<(String, String, String)> {
     let mut blind_system = council_blind_system();
     blind_system = append_optional_context(blind_system, domain_hint, false, persona);
@@ -509,7 +509,7 @@ async fn run_blind_phase_parallel(
         1500,
         blind_timeout,
         Some(cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -541,7 +541,7 @@ async fn run_xpol_phase_parallel(
     domain_hint: Option<&str>,
     display_names: &HashMap<String, String>,
     cost_tracker: &CostTracker,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> Vec<(String, String, String)> {
     let mut xpol_system = council_xpol_system();
     xpol_system = append_optional_context(xpol_system, domain_hint, false, persona);
@@ -585,7 +585,7 @@ async fn run_xpol_phase_parallel(
         1500,
         timeout.min(90.0),
         Some(cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -617,7 +617,7 @@ pub async fn run_followup_discussion(
     persona: Option<&str>,
     output: &mut dyn Output,
     cost_tracker: &CostTracker,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> String {
     let client = Client::new();
     let followup_models = &council_config[..council_config.len().min(2)];
@@ -672,7 +672,7 @@ pub async fn run_followup_discussion(
             timeout,
             2,
             Some(cost_tracker),
-            effort,
+            opts,
         )
         .await;
 
@@ -717,7 +717,7 @@ pub async fn run_council(
     cross_pollinate: bool,
     followup: bool,
     thorough: bool,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
     judge_model_override: Option<&str>,
     critic_model_override: Option<&str>,
     no_critic: bool,
@@ -751,7 +751,7 @@ pub async fn run_council(
             domain_hint,
             sub_questions.as_deref(),
             &cost_tracker,
-            effort,
+            opts,
         )
         .await;
 
@@ -856,7 +856,7 @@ pub async fn run_council(
             domain_hint,
             &display_names,
             &cost_tracker,
-            effort,
+            opts,
         )
         .await;
 
@@ -1045,7 +1045,7 @@ pub async fn run_council(
                     timeout,
                     2,
                     Some(&cost_tracker),
-                    effort.map(|e| e.step_down()),
+                    &QueryOptions::new(opts.effort.map(|e| e.step_down()), opts.web_search.clone()),
                 ),
             )
             .await
@@ -1347,7 +1347,7 @@ pub async fn run_council(
                     300.0,
                     2,
                     Some(&cost_tracker),
-                    effort,
+                    &QueryOptions::internal(),
                 )
                 .await;
 
@@ -1465,7 +1465,7 @@ pub async fn run_council(
             persona,
             output,
             &cost_tracker,
-            effort,
+            opts,
         )
         .await;
 

--- a/src/modes/discuss.rs
+++ b/src/modes/discuss.rs
@@ -3,7 +3,7 @@
 use crate::api::{query_model, run_parallel};
 use crate::config::{
     model_max_output_tokens, sanitize_speaker_content, CostTracker, Message, ModelEntry,
-    ReasoningEffort, SessionResult, DISCUSS_HOST,
+    QueryOptions, SessionResult, DISCUSS_HOST,
 };
 use crate::prompts::{
     discuss_host_closing, discuss_host_framing, discuss_host_steer, discuss_panelist_closing,
@@ -20,7 +20,6 @@ async fn compress_round_context(
     client: &Client,
     api_key: &str,
     cost_tracker: &CostTracker,
-    effort: Option<ReasoningEffort>,
 ) -> String {
     let mut round_summary = String::new();
     for (name, response) in round_responses {
@@ -42,7 +41,7 @@ async fn compress_round_context(
         30.0,
         2,
         Some(cost_tracker),
-        effort,
+        &QueryOptions::internal(),
     )
     .await;
 
@@ -75,7 +74,7 @@ pub async fn run_discuss(
     timeout: f64,
     output: &mut dyn Output,
     thorough: bool,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> SessionResult {
     let start = Instant::now();
     let cost_tracker = CostTracker::new();
@@ -124,7 +123,7 @@ pub async fn run_discuss(
         timeout,
         2,
         Some(&cost_tracker),
-        effort,
+        opts,
     )
     .await;
 
@@ -179,7 +178,7 @@ pub async fn run_discuss(
         500,
         timeout,
         Some(&cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -286,7 +285,7 @@ pub async fn run_discuss(
             timeout,
             2,
             Some(&cost_tracker),
-            effort,
+            opts,
         )
         .await;
 
@@ -364,7 +363,7 @@ pub async fn run_discuss(
                 timeout,
                 2,
                 Some(&cost_tracker),
-                effort,
+                opts,
             )
             .await;
 
@@ -382,15 +381,8 @@ pub async fn run_discuss(
             let round_responses = &conversation_history[round_start..];
             let _ = output.write_str(&format!("(compressing round {} context...)\n", round_num));
             let summary =
-                compress_round_context(
-                    round_responses,
-                    question,
-                    &client,
-                    api_key,
-                    &cost_tracker,
-                    effort,
-                )
-                .await;
+                compress_round_context(round_responses, question, &client, api_key, &cost_tracker)
+                    .await;
             compressed_summaries.push(summary);
         }
     }
@@ -442,7 +434,7 @@ pub async fn run_discuss(
         300,
         timeout,
         Some(&cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -500,7 +492,7 @@ pub async fn run_discuss(
         timeout,
         2,
         Some(&cost_tracker),
-        effort,
+        opts,
     )
     .await;
 

--- a/src/modes/forecast.rs
+++ b/src/modes/forecast.rs
@@ -3,7 +3,7 @@
 use crate::api::{query_model, run_parallel_with_different_messages};
 use crate::config::{
     model_max_output_tokens, sanitize_speaker_content, CostTracker, Message, ModelEntry,
-    SessionResult, DISCUSS_HOST,
+    QueryOptions, SessionResult, DISCUSS_HOST,
 };
 use crate::prompts::{
     forecast_blind_system, forecast_host_divergence, forecast_host_synthesis,
@@ -27,6 +27,7 @@ pub async fn run_forecast(
     _format: &str,
     timeout: f64,
     output: &mut dyn Output,
+    opts: &QueryOptions,
 ) -> SessionResult {
     let start = Instant::now();
     let cost_tracker = CostTracker::new();
@@ -65,7 +66,7 @@ pub async fn run_forecast(
         500,
         timeout,
         Some(&cost_tracker),
-        None,
+        opts,
         None,
     )
     .await;
@@ -106,7 +107,7 @@ pub async fn run_forecast(
         timeout,
         2,
         Some(&cost_tracker),
-        None,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_divergence));
@@ -151,7 +152,7 @@ pub async fn run_forecast(
         600,
         timeout,
         Some(&cost_tracker),
-        None,
+        opts,
         None,
     )
     .await;
@@ -192,7 +193,7 @@ pub async fn run_forecast(
         timeout,
         2,
         Some(&cost_tracker),
-        None,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_distribution));

--- a/src/modes/oxford.rs
+++ b/src/modes/oxford.rs
@@ -3,7 +3,7 @@
 use crate::api::{query_model, run_parallel_with_different_messages};
 use crate::config::{
     model_max_output_tokens, resolved_judge_model, sanitize_speaker_content, CostTracker, Message,
-    ModelEntry, ReasoningEffort, SessionResult,
+    ModelEntry, QueryOptions, SessionResult,
 };
 use crate::prompts::{
     oxford_closing_system, oxford_constructive_system, oxford_judge_prior, oxford_judge_verdict,
@@ -28,7 +28,7 @@ pub async fn run_oxford(
     _format: &str,
     timeout: f64,
     output: &mut dyn Output,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> SessionResult {
     let start = Instant::now();
     let cost_tracker = CostTracker::new();
@@ -62,7 +62,7 @@ pub async fn run_oxford(
             timeout,
             2,
             Some(&cost_tracker),
-            effort,
+            &QueryOptions::internal(),
         )
         .await;
         let m = m.trim().trim_matches('"').to_string();
@@ -105,7 +105,7 @@ pub async fn run_oxford(
         timeout,
         2,
         Some(&cost_tracker),
-        effort,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", prior_response));
@@ -147,7 +147,7 @@ pub async fn run_oxford(
         800,
         timeout,
         Some(&cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -205,7 +205,7 @@ pub async fn run_oxford(
         600,
         timeout,
         Some(&cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -255,7 +255,7 @@ pub async fn run_oxford(
         400,
         timeout,
         Some(&cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -307,7 +307,7 @@ pub async fn run_oxford(
         timeout,
         2,
         Some(&cost_tracker),
-        effort,
+        opts,
     )
     .await;
 

--- a/src/modes/premortem.rs
+++ b/src/modes/premortem.rs
@@ -3,7 +3,7 @@
 use crate::api::{query_model, run_parallel_with_different_messages};
 use crate::config::{
     model_max_output_tokens, sanitize_speaker_content, CostTracker, Message, ModelEntry,
-    SessionResult, DISCUSS_HOST,
+    QueryOptions, SessionResult, DISCUSS_HOST,
 };
 use crate::prompts::{
     premortem_host_framing, premortem_host_mitigation, premortem_host_synthesis,
@@ -27,6 +27,7 @@ pub async fn run_premortem(
     _format: &str,
     timeout: f64,
     output: &mut dyn Output,
+    opts: &QueryOptions,
 ) -> SessionResult {
     let start = Instant::now();
     let cost_tracker = CostTracker::new();
@@ -57,7 +58,7 @@ pub async fn run_premortem(
         timeout,
         2,
         Some(&cost_tracker),
-        None,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_setup));
@@ -99,7 +100,7 @@ pub async fn run_premortem(
         700,
         timeout,
         Some(&cost_tracker),
-        None,
+        opts,
         None,
     )
     .await;
@@ -145,7 +146,7 @@ pub async fn run_premortem(
         timeout,
         2,
         Some(&cost_tracker),
-        None,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_synthesis));
@@ -190,7 +191,7 @@ pub async fn run_premortem(
         timeout,
         2,
         Some(&cost_tracker),
-        None,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_mitigation));

--- a/src/modes/quick.rs
+++ b/src/modes/quick.rs
@@ -2,8 +2,8 @@
 
 use crate::api::{query_model_async, query_model_streaming};
 use crate::config::{
-    fallback_also_failed_message, is_error_response, model_max_output_tokens,
-    per_model_max_tokens, CostTracker, Message, ModelEntry, ReasoningEffort, SessionResult,
+    fallback_also_failed_message, is_error_response, model_max_output_tokens, per_model_max_tokens,
+    CostTracker, Message, ModelEntry, QueryOptions, SessionResult,
 };
 use crate::session::Output;
 use chrono::Local;
@@ -38,7 +38,7 @@ async fn run_quick_streaming(
     max_tokens: u32,
     timeout: f64,
     cost_tracker: &CostTracker,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
     output: &mut dyn Output,
 ) -> Vec<(String, String, String, u64)> {
     let client = Client::new();
@@ -61,10 +61,8 @@ async fn run_quick_streaming(
         let model_name = model.split('/').next_back().unwrap_or(&model).to_string();
         let model_max_tokens =
             model_max_output_tokens(&model).min(per_model_max_tokens(&model, max_tokens));
-        let fallback_owned: Option<(String, String)> =
-            fallback.map(|(provider, fallback_model)| {
-                (provider.to_string(), fallback_model.to_string())
-            });
+        let fallback_owned: Option<(String, String)> = fallback
+            .map(|(provider, fallback_model)| (provider.to_string(), fallback_model.to_string()));
         let google_api_key = google_api_key.map(|s| s.to_string());
         let zhipu_api_key = zhipu_api_key.map(|s| s.to_string());
         let moonshot_api_key = moonshot_api_key.map(|s| s.to_string());
@@ -72,6 +70,7 @@ async fn run_quick_streaming(
         let xai_api_key = xai_api_key.map(|s| s.to_string());
         let anthropic_api_key = anthropic_api_key.map(|s| s.to_string());
         let cost_tracker = cost_tracker.clone();
+        let opts = opts.clone();
 
         pending.push(async move {
             let participant_start = Instant::now();
@@ -85,13 +84,15 @@ async fn run_quick_streaming(
                 model_max_tokens,
                 timeout,
                 Some(&cost_tracker),
-                effort,
+                &opts,
                 &mut null_output,
             )
             .await;
 
             let mut used_model_name = model_name.clone();
-            let fallback_ref = fallback_owned.as_ref().map(|(p, m)| (p.as_str(), m.as_str()));
+            let fallback_ref = fallback_owned
+                .as_ref()
+                .map(|(p, m)| (p.as_str(), m.as_str()));
 
             // Fallback only if streaming failed.
             if is_error_response(&response) {
@@ -113,13 +114,12 @@ async fn run_quick_streaming(
                     timeout,
                     2,
                     Some(&cost_tracker),
-                    effort,
+                    &opts,
                 )
                 .await;
 
                 if is_error_response(&fb_response) {
-                    response =
-                        fallback_also_failed_message(&name, &primary_response, &fb_response);
+                    response = fallback_also_failed_message(&name, &primary_response, &fb_response);
                 } else {
                     used_model_name = fb_model_name;
                     response = fb_response;
@@ -136,7 +136,8 @@ async fn run_quick_streaming(
         });
     }
 
-    while let Some((name, _model_name, used_model_name, response, elapsed_ms)) = pending.next().await
+    while let Some((name, _model_name, used_model_name, response, elapsed_ms)) =
+        pending.next().await
     {
         let _ = output.begin_participant(&name);
         let _ = output.write_str(&format!("### {name}\n{response}\n\n"));
@@ -160,7 +161,7 @@ async fn run_quick_parallel(
     max_tokens: u32,
     timeout: f64,
     cost_tracker: &CostTracker,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> Vec<(String, String, String, u64)> {
     let client = Client::new();
     let mut pending = FuturesUnordered::new();
@@ -173,10 +174,8 @@ async fn run_quick_parallel(
         let model = model.to_string();
         let model_max_tokens =
             model_max_output_tokens(&model).min(per_model_max_tokens(&model, max_tokens));
-        let fallback_owned: Option<(String, String)> =
-            fallback.map(|(provider, fallback_model)| {
-                (provider.to_string(), fallback_model.to_string())
-            });
+        let fallback_owned: Option<(String, String)> = fallback
+            .map(|(provider, fallback_model)| (provider.to_string(), fallback_model.to_string()));
         let google_api_key = google_api_key.map(|s| s.to_string());
         let zhipu_api_key = zhipu_api_key.map(|s| s.to_string());
         let moonshot_api_key = moonshot_api_key.map(|s| s.to_string());
@@ -184,10 +183,13 @@ async fn run_quick_parallel(
         let xai_api_key = xai_api_key.map(|s| s.to_string());
         let anthropic_api_key = anthropic_api_key.map(|s| s.to_string());
         let cost_tracker = cost_tracker.clone();
+        let opts = opts.clone();
 
         pending.push(async move {
             let start = Instant::now();
-            let fallback_ref = fallback_owned.as_ref().map(|(p, m)| (p.as_str(), m.as_str()));
+            let fallback_ref = fallback_owned
+                .as_ref()
+                .map(|(p, m)| (p.as_str(), m.as_str()));
             let (speaker_name, used_model_name, response) = query_model_async(
                 &client,
                 &api_key,
@@ -205,7 +207,7 @@ async fn run_quick_parallel(
                 timeout,
                 2,
                 Some(&cost_tracker),
-                effort,
+                &opts,
             )
             .await;
             (
@@ -244,7 +246,7 @@ pub async fn run_quick(
     output: &mut dyn Output,
     format: &str,
     timeout: f64,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> SessionResult {
     let start = Instant::now();
     let cost_tracker = CostTracker::new();
@@ -279,7 +281,7 @@ pub async fn run_quick(
             2048,
             timeout,
             &cost_tracker,
-            effort,
+            opts,
             output,
         )
         .await
@@ -297,7 +299,7 @@ pub async fn run_quick(
             2048,
             timeout,
             &cost_tracker,
-            effort,
+            opts,
         )
         .await
     };
@@ -409,7 +411,10 @@ pub async fn run_quick(
         model_timings.insert(model_name.clone(), serde_json::Value::from(*elapsed_ms));
     }
     let mut extra = serde_json::Map::new();
-    extra.insert("model_timings".into(), serde_json::Value::Object(model_timings));
+    extra.insert(
+        "model_timings".into(),
+        serde_json::Value::Object(model_timings),
+    );
 
     SessionResult {
         transcript,

--- a/src/modes/redteam.rs
+++ b/src/modes/redteam.rs
@@ -3,7 +3,7 @@
 use crate::api::{query_model, run_parallel_with_different_messages};
 use crate::config::{
     model_max_output_tokens, sanitize_speaker_content, CostTracker, Message, ModelEntry,
-    ReasoningEffort, SessionResult, DISCUSS_HOST,
+    QueryOptions, SessionResult, DISCUSS_HOST,
 };
 use crate::prompts::{
     redteam_attacker_deepen, redteam_attacker_system, redteam_host_analysis, redteam_host_deepen,
@@ -27,7 +27,7 @@ pub async fn run_redteam(
     _format: &str,
     timeout: f64,
     output: &mut dyn Output,
-    effort: Option<ReasoningEffort>,
+    opts: &QueryOptions,
 ) -> SessionResult {
     let start = Instant::now();
     let cost_tracker = CostTracker::new();
@@ -58,7 +58,7 @@ pub async fn run_redteam(
         timeout,
         2,
         Some(&cost_tracker),
-        effort,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_analysis));
@@ -99,7 +99,7 @@ pub async fn run_redteam(
         600,
         timeout,
         Some(&cost_tracker),
-        effort,
+        opts,
         None,
     )
     .await;
@@ -145,7 +145,7 @@ pub async fn run_redteam(
         timeout,
         2,
         Some(&cost_tracker),
-        effort,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_deepen));
@@ -206,7 +206,7 @@ pub async fn run_redteam(
             timeout,
             2,
             Some(&cost_tracker),
-            effort,
+            opts,
         )
         .await;
 
@@ -247,7 +247,7 @@ pub async fn run_redteam(
         timeout,
         2,
         Some(&cost_tracker),
-        effort,
+        opts,
     )
     .await;
     let _ = output.write_str(&format!("{}\n\n", host_triage));

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -33,6 +33,26 @@ fn test_help_includes_examples() -> Result<(), Box<dyn std::error::Error>> {
         ))
         .stdout(predicate::str::contains("--judge-model"))
         .stdout(predicate::str::contains("--critic-model"))
-        .stdout(predicate::str::contains("--no-critic"));
+        .stdout(predicate::str::contains("--no-critic"))
+        .stdout(predicate::str::contains("--web-search"))
+        .stdout(predicate::str::contains("--web-engine"));
+    Ok(())
+}
+
+#[test]
+fn test_web_search_zero_rejected() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("consilium"));
+    cmd.args(["test question", "--web-search", "0"]);
+    cmd.assert().failure();
+    Ok(())
+}
+
+#[test]
+fn test_web_engine_requires_web_search() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("consilium"));
+    cmd.args(["test question", "--web-engine", "native"]);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("--web-search"));
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace bare `effort` parameter with `QueryOptions` struct across all mode functions and API calls
- Add `--web-search [N]` and `--web-engine` (exa/native/firecrawl/parallel) CLI flags
- Default to Exa for predictable pricing (~$0.02/req) — a single `--quick --web-search` run with native engine cost $3.15 vs ~$0.15 with Exa
- Skip native API fallbacks (Anthropic, xAI, Google, Zhipu) when web search is enabled since they don't support OpenRouter plugins
- Internal helper phases (critic, extraction, decompose, compression, classify, motion transform) use `QueryOptions::internal()` so session-level web search config doesn't leak into phases that don't need it

## Test plan
- [x] `cargo clippy` — 0 errors
- [x] `cargo test` — 85 tests pass (80 unit + 5 integration)
- [x] Smoke-tested `--quick --web-search` with factual query — citations present, cost ~$0.15
- [x] Verify `--web-engine native` produces higher cost on same query
- [x] Verify `--web-engine` without `--web-search` fails with helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)